### PR TITLE
Updates to boost::source recipe.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Gemfile.lock
 .*.sw[a-z]
 *.un~
 /cookbooks
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,49 @@
+---
+driver_plugin: vagrant
+
+driver_config:
+  customize:
+    memory: 1024
+
+platforms:
+
+- name: centos-6
+  driver_config:
+    box: opscode-centos-6.5
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+    require_chef_omnibus: latest
+- name: ubuntu-12.04
+  driver_config:
+    box: opscode-ubuntu-12.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+    require_chef_omnibus: latest
+- name: ubuntu-12.10
+  driver_config:
+    box: opscode-ubuntu-12.10
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.10_chef-provisionerless.box
+    require_chef_omnibus: latest
+- name: ubuntu-13.04
+  driver_config:
+    box: opscode-ubuntu-13.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.04_chef-provisionerless.box
+    require_chef_omnibus: latest
+- name: ubuntu-13.10
+  driver_config:
+    box: opscode-ubuntu-13.10
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.10_chef-provisionerless.box
+    require_chef_omnibus: latest
+- name: ubuntu-14.04
+  driver_config:
+    box: opscode-ubuntu-14.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+    require_chef_omnibus: latest
+
+suites:
+- name: boost
+  run_list:
+  - recipe[boost::default]
+  attributes: {}
+- name: boost-source
+  run_list:
+  - recipe[boost::source]
+  attributes: {}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,48 +2,30 @@
 driver_plugin: vagrant
 
 driver_config:
+  require_chef_omnibus: true
   customize:
-    memory: 1024
+    memory: 4096
+    cpus: 4
 
 platforms:
-
-- name: centos-6
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-    require_chef_omnibus: latest
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
-    require_chef_omnibus: latest
-- name: ubuntu-12.10
-  driver_config:
-    box: opscode-ubuntu-12.10
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.10_chef-provisionerless.box
-    require_chef_omnibus: latest
-- name: ubuntu-13.04
-  driver_config:
-    box: opscode-ubuntu-13.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.04_chef-provisionerless.box
-    require_chef_omnibus: latest
-- name: ubuntu-13.10
-  driver_config:
-    box: opscode-ubuntu-13.10
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.10_chef-provisionerless.box
-    require_chef_omnibus: latest
-- name: ubuntu-14.04
-  driver_config:
-    box: opscode-ubuntu-14.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
-    require_chef_omnibus: latest
+  - name: opscode-centos-6.5
+  - name: opscode-debian-7.2.0
+  - name: opscode-fedora-19
+  - name: opscode-ubuntu-14.04
 
 suites:
-- name: boost
+- name: default
   run_list:
   - recipe[boost::default]
   attributes: {}
-- name: boost-source
+- name: source
   run_list:
   - recipe[boost::source]
-  attributes: {}
+  attributes: 
+    boost:
+      source:
+        major_ver: "1"
+        minor_ver: "57"
+        patch_ver: "0"
+        file_ext: ".bz2"
+        build_cmd: "./bootstrap.sh && ./b2 -j 4 install"

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
-site 'https://supermarket.chef.io'
+source 'https://supermarket.chef.io'
 
 metadata
+cookbook 'build-essential'

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-cookbook 'build-essential'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source :rubygems
 
 gem 'berkshelf'
 gem 'vagrant', '~> 1.0.5'
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,1 @@
-source :rubygems
-
-gem 'berkshelf'
-gem 'vagrant', '~> 1.0.5'
-gem "test-kitchen"
-gem "kitchen-vagrant"
+source "https://rubygems.org"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 Description
 ===========
 
-Installs boost, mainly to support Thrift.
+Installs the [Boost](http://boost.org) development headers/libraries.
 
 Requirements
 ============
 
 ## Platform:
 
-* Ubuntu 10.04
+* CentOS 
+* Ubuntu
+* Fedora
 
 Usage
 =====
@@ -17,7 +19,15 @@ Include this recipe to install boost development packages.
 
     include_recipe "boost"
 
-Merely installs the libboost-dev package which should grab a bunch of dependencies and get the right thing.
+Merely installs the boost development packages for a particular
+platform. 
+
+Boost can also be built from source by using the following recipe:
+
+    include_recipe "boost::source"
+
+This recipe downloads the tarbal, compiles and installs the boost
+system.
 
 License and Author
 ==================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,0 @@
-default['boost']['source'] = "http://sourceforge.net/projects/boost/files/boost/1.58.0/"
-default['boost']['file'] = "boost_1_58_0.tar.gz"
-default['boost']['build_dir'] = "boost_1_58_0"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
-default['boost']['source'] = "http://sourceforge.net/projects/boost/files/boost/1.51.0/"
-default['boost']['file'] = "boost_1_51_0.tar.gz"
-default['boost']['build_dir'] = "boost_1_51_0"
+default['boost']['source'] = "http://sourceforge.net/projects/boost/files/boost/1.58.0/"
+default['boost']['file'] = "boost_1_58_0.tar.gz"
+default['boost']['build_dir'] = "boost_1_58_0"

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -1,0 +1,51 @@
+# The appropriate tarbal and download url can be constructed by the 
+# three-part boost version. i.e. 1.58.0. Therefore, it's normally only
+# required to override the first few attributes.
+
+# Major version number
+default['boost']['source']['major_ver'] = "1"
+
+# Minor version number
+default['boost']['source']['minor_ver'] = "58"
+
+# Patch version number
+default['boost']['source']['patch_ver'] = "0"
+
+# Base url where tarbal is downloaded from
+default['boost']['source']['base_url'] = "http://sourceforge.net/projects/boost/files/boost"
+
+# Tarbal download is either .gz or .bz2 compressed
+default['boost']['source']['file_ext'] = ".gz"
+
+# Tarbal has base file name in format of 'boost_1_58_0'
+default['boost']['source']['file_base'] = 
+    "boost_"\
+    "#{node['boost']['source']['major_ver']}_"\
+    "#{node['boost']['source']['minor_ver']}_"\
+    "#{node['boost']['source']['patch_ver']}"
+
+# File name is 'boost_1_58_0.tar.gz' or 'boost_1_58_0.tar.bz2'
+default['boost']['source']['file'] = 
+    "#{node['boost']['source']['file_base']}"\
+    ".tar"\
+    "#{node['boost']['source']['file_ext']}"
+
+# Download url is constructed from base_url
+default['boost']['source']['download_url'] = 
+    "#{node['boost']['source']['base_url']}/"\
+    "#{node['boost']['source']['major_ver']}."\
+    "#{node['boost']['source']['minor_ver']}."\
+    "#{node['boost']['source']['patch_ver']}/"\
+    "#{node['boost']['source']['file']}"
+
+# The build directory is where the tar command extracts to. There is no 
+# need to change this.
+default['boost']['source']['build_dir'] = "#{node['boost']['source']['file_base']}"
+
+# Location where boost gets installed
+default['boost']['source']['install_prefix'] = "/usr/local"
+
+# The boost build command to compile and run
+default['boost']['source']['build_cmd'] = 
+    "./bootstrap.sh --prefix=#{node['boost']['source']['install_prefix']} && "\
+    "./b2 install"

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,9 @@ version          "0.3.0"
 name             "boost"
 provides         "boost"
 recipe           "boost", "Installs libboost-dev"
+recipe           "boost::source", "Installs boost via source tarbal compile."
 
+depends          "apt"
 depends          "build-essential"
 
 supports "ubuntu"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email "cookbooks@chef.io"
 license          "Apache 2.0"
 description      "Installs libboost"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"
 name             "boost"
 provides         "boost"
 recipe           "boost", "Installs libboost-dev"
 
-recommends       "build-essential"
+depends          "build-essential"
 
 supports "ubuntu"
 supports "debian"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe "apt"
+
 case node['platform_family']
 when "rhel","fedora"
   %w{boost boost-devel boost-doc}.each do |pkg|

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -6,13 +6,21 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{node['boost']['file']}" do
   action :create_if_missing
 end
 
+# centos needs python and bzip2
+case node[:platform]
+when "centos"
+  %w{python-devel bzip2-devel}.each do |pkg|
+    package pkg
+  end
+end
+
 bash "install-boost" do
   user "root"
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
   tar xzvf #{node['boost']['file']}
   cd #{node['boost']['build_dir']}
-  ./bootstrap.sh && ./bjam install
+  ./bootstrap.sh && ./b2 install
   EOH
   not_if "/sbin/ldconfig -v | grep boost"
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,28 +1,41 @@
+include_recipe "apt"
 include_recipe "build-essential"
 
-remote_file "#{Chef::Config[:file_cache_path]}/#{node['boost']['file']}" do
-  source node['boost']['source'] + node['boost']['file']
+tar_file = node['boost']['source']['file']
+remote_file "#{Chef::Config[:file_cache_path]}/#{tar_file}" do
+  source node['boost']['source']['download_url']
   mode "0644"
   action :create_if_missing
 end
 
-# centos needs python and bzip2
-case node[:platform]
-when "centos"
-  %w{python-devel bzip2-devel}.each do |pkg|
-    package pkg
-  end
+# python headers and bzip needed for full boost compile
+case node['platform']
+when "centos","rhel","fedora"
+    %w{python-devel bzip2-devel}.each do |pkg|
+        package pkg
+    end
+when "ubuntu","debian"
+    %w{python-dev libbz2-dev}.each do |pkg|
+        package pkg
+    end
+end
+
+case File.extname(tar_file)
+when ".gz"
+  tar_cmd = "tar xzvf #{tar_file}"
+else
+  tar_cmd = "tar xjvf #{tar_file}"
 end
 
 bash "install-boost" do
   user "root"
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
-  tar xzvf #{node['boost']['file']}
-  cd #{node['boost']['build_dir']}
-  ./bootstrap.sh && ./b2 install
+  #{tar_cmd}
+  cd #{node['boost']['source']['build_dir']}
+  #{node['boost']['source']['build_cmd']}
   EOH
-  not_if "/sbin/ldconfig -v | grep boost"
+  not_if { File.exist?("#{node['boost']['source']['install_prefix']}/boost/version.hpp") }
 end
 
 execute "ldconfig" do

--- a/test/integration/source/serverspec/boost_spec.rb
+++ b/test/integration/source/serverspec/boost_spec.rb
@@ -1,0 +1,12 @@
+require 'serverspec'
+
+# We placed this file here, it should be there.
+describe file('/etc/ld.so.conf.d/boost.conf') do
+    it { should be_file }
+end
+
+# Ensure boost/version header there
+describe file('/usr/local/include/boost/version.hpp') do
+    it { should be_file }
+    its(:content) { should match /define BOOST_LIB_VERSION "\d_\d\d"/ }
+end


### PR DESCRIPTION
Hello,

I've done some spiffing up the boost cookbook but specifically expanded on the boost::source recipe, which builds boost from a downloaded tarbal.

This recipe comes in super handy for systems with older versions of the boost rpm's as being able to build from source can get you the latest. The recipe definitely existed prior to my contribution but it was a little cumbersome and error prone for some systems.

Prior to this change the source builds would completely fail on most platforms I tried (using vagrant). The problem being missing dependencies to python development package and bzip2 development package. 

Please let me know if there are any questions or recommendations on how to improve this. The last week has been my first dive into chef so I'm definitely open to learning. 